### PR TITLE
add sof-firmware package as its essential

### DIFF
--- a/src/src/functions/base.rs
+++ b/src/src/functions/base.rs
@@ -25,6 +25,7 @@ pub fn install_base_packages(kernel: String) {
         kernel_to_install,
         format!("{kernel_to_install}-headers").as_str(),
         "linux-firmware",
+        "sof-firmware", // required for newer sound cards [ESSENTIAL]
         "man-db",
         "man-pages",
         "nano",


### PR DESCRIPTION
It is required for newer sound cards and should be installed with the user 